### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.3
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
     "prop-types": "^15.6.0",
     "react": "^16.8.0",
     "react-dom": "^16.0.0"
+  },
+  "standard": {
+    "ignore": [
+      "/lib/ReactTinderCard.js"
+    ]
   }
 }


### PR DESCRIPTION
This sets up so that `npm test` is run on GitHub Actions for every PR that is made.

edit: it seems like only repo owners can create workflows, see if you can enable it from here maybe: https://github.com/3DJakob/react-tinder-card/actions/new