### PR TITLE
Add a `param` prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ const mouseCoordinatesFromEvent = (e) => {
   return { x: e.clientX, y: e.clientY }
 }
 
-const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipeClinched, onSwipeUpdate, onSwipeInitiated, onCardLeftScreen, className, preventSwipe = [], params={} }, ref) => {
+const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipeClinched, onSwipeUpdate, onSwipeInitiated, onSwipeCameBack, onCardLeftScreen, className, preventSwipe = [], params={} }, ref) => {
   const swipeAlreadyReleased = React.useRef(false)
 
   settings = Object.assign(settings, params)
@@ -176,11 +176,12 @@ const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipeCli
           return
         }
       }
+    } else {
+      // Card was not flicked away, animate back to start
+      if (onSwipeCameBack) onSwipeCameBack()
+      animateBack(element)
     }
-
-    // Card was not flicked away, animate back to start
-    animateBack(element)
-  }, [swipeAlreadyReleased, flickOnSwipe, onSwipeClinched, onCardLeftScreen, preventSwipe])
+  }, [swipeAlreadyReleased, flickOnSwipe, onSwipeClinched, onSwipeCameBack, onCardLeftScreen, preventSwipe])
 
   const handleSwipeStart = React.useCallback(() => {
     if (onSwipeInitiated) onSwipeInitiated()

--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@
 const React = require('react')
 const sleep = require('p-sleep')
 
-const settings = {
+let settings = {
   snapBackDuration: 300,
   maxTilt: 5,
   bouncePower: 0.2,
-  swipeThreshold: 300 // px/s
+  swipeThreshold: 300, // px/s
+  passive: true
 }
 
 const getElementSize = (element) => {
@@ -130,8 +131,10 @@ const mouseCoordinatesFromEvent = (e) => {
   return { x: e.clientX, y: e.clientY }
 }
 
-const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [] }, ref) => {
+const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], params={} }, ref) => {
   const swipeAlreadyReleased = React.useRef(false)
+
+  settings = Object.assign(settings, params)
 
   const element = React.useRef()
 
@@ -192,7 +195,7 @@ const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, o
       ev.preventDefault()
       handleSwipeStart()
       offset = { x: -touchCoordinatesFromEvent(ev).x, y: -touchCoordinatesFromEvent(ev).y }
-    })
+    }, { passive: settings.passive })
 
     element.current.addEventListener(('mousedown'), (ev) => {
       ev.preventDefault()
@@ -206,7 +209,7 @@ const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, o
       const newLocation = dragableTouchmove(touchCoordinatesFromEvent(ev), element.current, offset, lastLocation)
       speed = calcSpeed(lastLocation, newLocation)
       lastLocation = newLocation
-    })
+    }, { passive: settings.passive })
 
     element.current.addEventListener(('mousemove'), (ev) => {
       ev.preventDefault()
@@ -220,7 +223,7 @@ const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, o
     element.current.addEventListener(('touchend'), (ev) => {
       ev.preventDefault()
       handleSwipeReleased(element.current, speed)
-    })
+    }, { passive: settings.passive })
 
     element.current.addEventListener(('mouseup'), (ev) => {
       if (mouseIsClicked) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinder-card",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A npm react module for making react elements swipeable like in the dating app tinder.",
   "repository": "3DJakob/react-tinder-card",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinder-card",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A npm react module for making react elements swipeable like in the dating app tinder.",
   "repository": "3DJakob/react-tinder-card",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinder-card",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A npm react module for making react elements swipeable like in the dating app tinder.",
   "repository": "3DJakob/react-tinder-card",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,10 @@ const onSwipeClinched = (direction) => {
   console.log('You swiped: ' + direction)
 }
 
+const onSwipeCameBack = () => {
+  console.log('Your swipe came back to its original position')
+}
+
 const onCardLeftScreen = (myIdentifier) => {
   console.log(myIdentifier + ' left the screen')
 }
@@ -97,6 +101,13 @@ Callback that will be executed when a swipe is updated (i.e is moving). It will 
 - type: `SwipeHandler`
 
 Callback that will be executed when a swipe has been completed. It will be called with a single string denoting which direction the swipe was in: `'left'`, `'right'`, `'up'` or `'down'`.
+
+### `onSwipeCameBack`
+
+- optional
+- type: `SwipeHandler`
+
+Callback that will be executed when a swipe come back to its original position (i.e is not flicked away).
 
 ### `onCardLeftScreen`
 

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,23 @@ Callback that will be executed when a `TinderCard` has left the screen. It will 
 
 An array of directions for which to prevent swiping out of screen. Valid arguments are `'left'`, `'right'`, `'up'` and `'down'`.
 
+### `params`
+
+- optional
+- type: `Object`
+- default: `{}`
+
+An object overriding default settings:
+```
+{
+  snapBackDuration: 300,
+  maxTilt: 5,
+  bouncePower: 0.2,
+  swipeThreshold: 300, // px/s
+  passive: true // see https://developers.google.com/web/updates/2017/01/scrolling-intervention
+}
+```
+
 ## API
 
 ### `swipe([dir])`

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,15 @@ import TinderCard from 'react-tinder-card'
 
 // ...
 
-const onSwipe = (direction) => {
+const onSwipeInitiated = () => {
+  console.log('You started a swipe')
+}
+
+const onSwipeUpdate = (direction) => {
+  console.log('You are swiping: ' + direction)
+}
+
+const onSwipeClinched = (direction) => {
   console.log('You swiped: ' + direction)
 }
 
@@ -41,7 +49,13 @@ const onCardLeftScreen = (myIdentifier) => {
 }
 
 return (
-  <TinderCard onSwipe={onSwipe} onCardLeftScreen={() => onCardLeftScreen('fooBar')} preventSwipe={['right', 'left']}>Hello, World!</TinderCard>
+  <TinderCard
+    onSwipeClinched={onSwipeClinched}
+    onCardLeftScreen={() => onCardLeftScreen('fooBar')}
+    preventSwipe={['right', 'left']}
+  >
+    Hello, World!
+  </TinderCard>
 )
 ```
 
@@ -63,7 +77,21 @@ Both Web code examples can be tested on the [demo page.](https://3djakob.github.
 
 Whether or not to let the element be flicked away off-screen after a swipe.
 
-### `onSwipe`
+### `onSwipeInitiated`
+
+- optional
+- type: `SwipeHandler`
+
+Callback that will be executed when a swipe starts.
+
+### `onSwipeUpdate`
+
+- optional
+- type: `SwipeHandler`
+
+Callback that will be executed when a swipe is updated (i.e is moving). It will be called with a single string denoting which direction the swipe was in: `'left'`, `'right'`, `'up'` or `'down'`.
+
+### `onSwipeClinched`
 
 - optional
 - type: `SwipeHandler`
@@ -98,6 +126,7 @@ An object overriding default settings:
   maxTilt: 5,
   bouncePower: 0.2,
   swipeThreshold: 300, // px/s
+  getSpeedUpdate: false, // set this to true if you want to use onSwipeUpdate
   passive: true // see https://developers.google.com/web/updates/2017/01/scrolling-intervention
 }
 ```


### PR DESCRIPTION
I needed to have the ability to edit the `addEventListener` calls for touch events to remove a non-blocking error firing at each call (see https://developers.google.com/web/updates/2017/01/scrolling-intervention).
Since I added a `param` prop for this, I figured out it could be useful to have control over the animations settings as well.

It's all optional so anything already written can handle this new version and will work the same way as before, without having to change anything.