### PR TITLE
Add `rotateOnDrag` prop to give ability to disable rotation on drag

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,13 @@ declare interface Props {
   onSwipeRequirementUnfulfilled?: SwipeRequirementUnfufillUpdate
 
   /**
+   * Enable or disable rotating the card when dragging. Not rotating the card gives better performance.
+   *
+   * @default true
+   */
+   rotateOnDrag: boolean
+
+  /**
    * HTML attribute class
    */
   className?: string

--- a/index.js
+++ b/index.js
@@ -69,10 +69,10 @@ const animateBack = async (element) => {
   element.style.transform = translation + rotation
 
   await sleep(settings.snapBackDuration * 0.75)
-  element.style.transform = 'none'
+  element.style.removeProperty("transform");
 
   await sleep(settings.snapBackDuration)
-  element.style.transition = '10ms'
+  element.style.removeProperty("transition");
 }
 
 const getSwipeDirection = (property) => {

--- a/index.js
+++ b/index.js
@@ -123,12 +123,16 @@ const getRotation = (element) => {
   return ans
 }
 
-const dragableTouchmove = (coordinates, element, offset, lastLocation) => {
+const dragableTouchmove = (coordinates, element, offset, lastLocation, rotateOnDrag) => {
   const pos = { x: coordinates.x + offset.x, y: coordinates.y + offset.y }
   const newLocation = { x: pos.x, y: pos.y, time: new Date().getTime() }
   const translation = translationString(pos.x, pos.y)
-  const rotCalc = calcSpeed(lastLocation, newLocation).x / 1000
-  const rotation = rotationString(rotCalc * settings.maxTilt)
+  let rotation = "";
+  if(rotateOnDrag) {
+    const rotCalc = calcSpeed(lastLocation, newLocation).x / 1000
+    rotation = rotationString(rotCalc * settings.maxTilt)
+  }
+  
   element.style.transform = translation + rotation
   return newLocation
 }
@@ -142,7 +146,7 @@ const mouseCoordinatesFromEvent = (e) => {
   return { x: e.clientX, y: e.clientY }
 }
 
-const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], swipeRequirementType = 'velocity', swipeThreshold = settings.swipeThreshold, onSwipeRequirementFulfilled, onSwipeRequirementUnfulfilled }, ref) => {
+const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], swipeRequirementType = 'velocity', swipeThreshold = settings.swipeThreshold, onSwipeRequirementFulfilled, onSwipeRequirementUnfulfilled, rotateOnDrag = true }, ref) => {
   settings.swipeThreshold = swipeThreshold
   const swipeAlreadyReleased = React.useRef(false)
 
@@ -236,7 +240,7 @@ const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, o
       }
 
       // Move
-      const newLocation = dragableTouchmove(coordinates, element.current, offset, lastLocation)
+      const newLocation = dragableTouchmove(coordinates, element.current, offset, lastLocation, rotateOnDrag)
       speed = calcSpeed(lastLocation, newLocation)
       lastLocation = newLocation
     }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ const TinderCard = React.forwardRef(({ flickOnSwipe = true, children, onSwipe, o
       if (onCardLeftScreen) onCardLeftScreen(dir)
     },
     async restoreCard () {
-      element.current.style.display = 'block'
+      element.current.style.removeProperty('display')
       await animateBack(element.current)
     }
   }))

--- a/index.native.js
+++ b/index.native.js
@@ -86,7 +86,7 @@ const AnimatedView = animated(View)
 
 const TinderCard = React.forwardRef(
   (
-    { flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], swipeRequirementType = 'velocity', swipeThreshold = settings.swipeThreshold, onSwipeRequirementFulfilled, onSwipeRequirementUnfulfilled },
+    { flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], swipeRequirementType = 'velocity', swipeThreshold = settings.swipeThreshold, onSwipeRequirementFulfilled, onSwipeRequirementUnfulfilled, rotateOnDrag = true },
     ref
   ) => {
     const [{ x, y, rot }, setSpringTarget] = useSpring(() => ({
@@ -183,8 +183,11 @@ const TinderCard = React.forwardRef(
 
             // use guestureState.vx / guestureState.vy for velocity calculations
             // translate element
-            let rot = ((300 * gestureState.vx) / width) * 15// Magic number 300 different on different devices? Run on physical device!
-            rot = Math.max(Math.min(rot, settings.maxTilt), -settings.maxTilt)
+            let rot = 0;
+            if(rotateOnDrag) {
+              rot = ((300 * gestureState.vx) / width) * 15// Magic number 300 different on different devices? Run on physical device!
+              rot = Math.max(Math.min(rot, settings.maxTilt), -settings.maxTilt)
+            }
             setSpringTarget({ x: gestureState.dx, y: gestureState.dy, rot, config: physics.touchResponsive })
           },
           onPanResponderTerminationRequest: (evt, gestureState) => {


### PR DESCRIPTION
Add rotateOnDrag prop

The current rotation on drag implementation (web) works decently for smaller-sized cards like in the demo, but gets fairly janky for larger cards, especially when using the mouse on desktop.

This option allows the consumer to opt out of rotating on drag.

I've forked the demo to create a comparison: https://github.com/cgat/react-tinder-card-demo/tree/cgat/react-tinder-card-demo

Here's the demo. The first example is the current version of react-tinder-card. The second version is my update to react-tinder-card with the `rotateOnDrag` option set to `true` (default value). This should mostly be the same, but is also used to demonstrate a couple other fixes I added don't break things. The 3rd version is my update with `rotateOnDrag` set to `false`.
https://share.getcloudapp.com/xQujoXoG

To see what react-tinder-card looks like with bigger cards, I changed the card sizes in chrome inspector.
https://share.getcloudapp.com/d5u6X7qp

Haven't been able to test the react native change, but in theory it should work as well (likely less of an issue on native though)