### PR TITLE
fix animateBack snapBackDuration delay

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const animateBack = async (element) => {
   await sleep(settings.snapBackDuration * 0.75)
   element.style.transform = 'none'
 
-  await sleep(settings.snapBackDuration)
+  await sleep(settings.snapBackDuration * 0.25)
   element.style.transition = '10ms'
 }
 


### PR DESCRIPTION
in this commit https://github.com/3DJakob/react-tinder-card/commit/95080d0b759cf518d3c3388a7f9c70db5a326ef4 setTimeout was replaced by sleep async function. To preserve the previous behavior the total sleep time has to be  snapBackDuration*.75+snapBackDuration*.25.