### PR TITLE
fix: changed dependency react-spring to @react-spring/native and fixed deprecated method

### DIFF
--- a/index.native.js
+++ b/index.native.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const { View, PanResponder, Dimensions } = require('react-native')
-const { useSpring, animated } = require('react-spring/native')
+const { useSpring, animated } = require('@react-spring/native')
 const { height, width } = Dimensions.get('window')
 
 const settings = {
@@ -207,7 +207,7 @@ const TinderCard = React.forwardRef(
           transform: [
             { translateX: x },
             { translateY: y },
-            { rotate: rot.interpolate((rot) => `${rot}deg`) }
+            { rotate: rot.to((rot) => `${rot}deg`) }
           ]
         }}
         className={className}

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.0.0 || ^17.0.0",
-    "react-spring": "^8.0.0"
+    "@react-spring/native": "^8.0.0"
   },
   "peerDependenciesMeta": {
-    "react-spring": {
+    "@react-spring/native": {
       "optional": true
     }
   },


### PR DESCRIPTION
Changed dependency react-spring to @react-spring/native and fixed deprecated method FrameValue.interpolate in favor of FrameValue.to. See docs [here](https://react-spring.io/common/interpolation#interpolations). Fixes #53 