### PR TITLE
Add explicit optional children attribute to TinderCard Props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare interface API {
    * @param dir The direction in which the card should be swiped. One of: `'left'`, `'right'`, `'up'` and `'down'`.
    */
   swipe(dir?: Direction): Promise<void>
-  
+
   /**
    * Restore swiped-card state. Use this function if you want to undo a swiped-card (e.g. you have a back button that shows last swiped card or you have a reset button. The promise is resolved once the card is returned
    */
@@ -50,7 +50,7 @@ declare interface Props {
   /**
    * What method to evaluate what direction to throw the card on release. 'velocity' will evaluate direction based on the direction of the swiping movement. 'position' will evaluate direction based on the position the card has on the screen like in the app tinder.
    * If set to position it is recommended to manually set swipeThreshold based on the screen size as not all devices will accommodate the default distance of 300px and the default native swipeThreshold is 1px which most likely is undesirably low.
-   * 
+   *
    * @default 'velocity'
    */
   swipeRequirementType?: 'velocity' | 'position'
@@ -59,7 +59,7 @@ declare interface Props {
    * The threshold of which to accept swipes. If swipeRequirementType is set to velocity it is the velocity threshold and if set to position it is the position threshold.
    * On native the default value is 1 as the physics works differently there.
    * If swipeRequirementType is set to position it is recommended to set this based on the screen width so cards can be swiped on all screen sizes.
-   * 
+   *
    * @default 300
    */
   swipeThreshold?: number
@@ -79,6 +79,11 @@ declare interface Props {
    * HTML attribute class
    */
   className?: string
+
+  /**
+   * The children passed in is what will be rendered as the actual Tinder-style card.
+   */
+  children?: React.ReactNode
 }
 
 declare const TinderCard: React.FC<Props>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^16.9.51",
     "standard": "^14.3.1",
-    "ts-readme-generator": "^0.7.1"
+    "ts-readme-generator": "^0.7.2"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,13 @@ Callback that will be executed when a `TinderCard` has unfulfilled the requireme
 
 HTML attribute class
 
+### `children`
+
+- optional
+- type: `React.ReactNode`
+
+The children passed in is what will be rendered as the actual Tinder-style card.
+
 ## API
 
 ### `swipe([dir])`


### PR DESCRIPTION
Added explicit optional children attribute to TinderCard Props as required by React 18. See changes [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210). Fixes #91.