### PR TITLE
docs: Add instructions for installing React Native peer dependencies (`react-spring`)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,14 @@ Want to contribute? Check out the [contributing.md](https://github.com/3DJakob/r
 npm install --save react-tinder-card
 ```
 
+### React Native
+
+Additionally, if you are using React Native, you will need to install `react-spring` version 8.
+
+```sh
+npm install --save "react-spring@^8.0.0"
+```
+
 ## Usage
 
 Import TinderCard and use the component like the snippet. Note that the component will not remove itself after swipe. If you want that behaviour implement that on the `onCardLeftScreen` callback. It is recommended to have `overflow: hidden` on your `#root` to prevent cards from being visible after they go of screen.


### PR DESCRIPTION
This will help avoid React Native users having issues like #53.

Might be unnecessary once #96 is merged, but I am not sure if that has other consequences.

In the mean time, this update to the docs would be helpful.