### PR TITLE
Only prevent default if card click and is cancelable

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,9 @@ const TinderCard = React.forwardRef(
 
     React.useLayoutEffect(() => {
       element.current.addEventListener(('touchstart'), (ev) => {
-        ev.preventDefault()
+        if (ev.srcElement.className.includes('card') && ev.cancelable) {
+          ev.preventDefault()
+        }
       })
     })
 


### PR DESCRIPTION
This PR fixes issues related to not being able to click elements inside the card without the touchstart/touchend workaround https://github.com/3DJakob/react-tinder-card/issues/107 https://github.com/3DJakob/react-tinder-card/issues/92 https://github.com/3DJakob/react-tinder-card/issues/37 https://github.com/3DJakob/react-tinder-card/issues/86 https://github.com/3DJakob/react-tinder-card/issues/75 https://github.com/3DJakob/react-tinder-card/issues/79 https://github.com/3DJakob/react-tinder-card/issues/55 https://github.com/3DJakob/react-tinder-card/issues/14

It also fixes the issue clicking near the border described in https://github.com/3DJakob/react-tinder-card/issues/38