### PR TITLE
Remove react panresponder web

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,6 +220,7 @@ const TinderCard = React.forwardRef(
       })
 
       window.addEventListener(('mouseup'), (ev) => {
+        if (!isClicking) return
         isClicking = false
         handleSwipeReleased(setSpringTarget, lastPosition)
         startPositon = { x: 0, y: 0 }

--- a/index.js
+++ b/index.js
@@ -150,8 +150,14 @@ const TinderCard = React.forwardRef(
     let swipeThresholdFulfilledDirection = 'none'
 
     const gestureStateFromWebEvent = (ev, startPositon, lastPosition, isTouch) => {
-      const dx = isTouch ? ev.touches[0].clientX - startPositon.x : ev.clientX - startPositon.x
-      const dy = isTouch ? ev.touches[0].clientY - startPositon.y : ev.clientY - startPositon.y
+      let dx = isTouch ? ev.touches[0].clientX - startPositon.x : ev.clientX - startPositon.x
+      let dy = isTouch ? ev.touches[0].clientY - startPositon.y : ev.clientY - startPositon.y
+
+      // We cant calculate velocity from the first event
+      if (startPositon.x === 0 && startPositon.y === 0) {
+        dx = 0
+        dy = 0
+      }
 
       const vx = -(dx - lastPosition.dx) / (lastPosition.timeStamp - Date.now())
       const vy = -(dy - lastPosition.dy) / (lastPosition.timeStamp - Date.now())

--- a/index.js
+++ b/index.js
@@ -149,18 +149,27 @@ const TinderCard = React.forwardRef(
 
     let swipeThresholdFulfilledDirection = 'none'
 
+    const gestureStateFromWebTouchEvent = (ev, startPositon, lastPosition) => {
+      const dx = ev.touches[0].clientX - startPositon.x
+      const dy = ev.touches[0].clientY - startPositon.y
+
+      const vx = -(dx - lastPosition.dx) / (lastPosition.timeStamp - Date.now())
+      const vy = -(dy - lastPosition.dy) / (lastPosition.timeStamp - Date.now())
+
+      const gestureState = { dx, dy, vx, vy, timeStamp: Date.now() }
+      return gestureState
+    }
+
     React.useLayoutEffect(() => {
       let startPositon = { x: 0, y: 0 }
       let lastPosition = { dx: 0, dy: 0, vx: 0, vy: 0, timeStamp: Date.now() }
 
       element.current.addEventListener(('touchstart'), (ev) => {
-        const dx = ev.touches[0].clientX - startPositon.x
-        const dy = ev.touches[0].clientY - startPositon.y
+        if (!ev.srcElement.className.includes('pressable') && ev.cancelable) {
+          ev.preventDefault()
+        }
 
-        const vx = -(dx - lastPosition.dx) / (lastPosition.timeStamp - Date.now())
-        const vy = -(dy - lastPosition.dy) / (lastPosition.timeStamp - Date.now())
-
-        const gestureState = { dx, dy, vx, vy, timeStamp: Date.now() }
+        const gestureState = gestureStateFromWebTouchEvent(ev, startPositon, lastPosition)
         lastPosition = gestureState
 
         startPositon = { x: ev.touches[0].clientX, y: ev.touches[0].clientY }
@@ -171,13 +180,7 @@ const TinderCard = React.forwardRef(
       })
 
       element.current.addEventListener(('touchmove'), (ev) => {
-        const dx = ev.touches[0].clientX - startPositon.x
-        const dy = ev.touches[0].clientY - startPositon.y
-
-        const vx = -(dx - lastPosition.dx) / (lastPosition.timeStamp - Date.now())
-        const vy = -(dy - lastPosition.dy) / (lastPosition.timeStamp - Date.now())
-
-        const gestureState = { dx, dy, vx, vy, timeStamp: Date.now() }
+        const gestureState = gestureStateFromWebTouchEvent(ev, startPositon, lastPosition)
 
         lastPosition = gestureState
 
@@ -212,14 +215,6 @@ const TinderCard = React.forwardRef(
     })
 
     const element = React.useRef()
-
-    React.useLayoutEffect(() => {
-      element.current.addEventListener(('touchstart'), (ev) => {
-        if (!ev.srcElement.className.includes('pressable') && ev.cancelable) {
-          ev.preventDefault()
-        }
-      })
-    })
 
     return (
       React.createElement(AnimatedDiv, {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "test": "standard && ts-readme-generator --check"
   },
   "dependencies": {
-    "p-sleep": "^1.1.0",
-    "react-panresponder-web": "^1.0.2"
+    "p-sleep": "^1.1.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.51",


### PR DESCRIPTION
This patch removes the dependency `react-panresponder-web` as it was causing issues with react 18 as discussed in https://github.com/3DJakob/react-tinder-card-demo/issues/43 while trying to still share as much of the code base between native and web.