### PR TITLE
[feat]: add slow back animation prop for better ux

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,13 @@ declare interface Props {
   preventSwipe?: string[]
 
   /**
+   * The card return animation is slow.
+   *
+   * @default false
+   */
+  slowBackAnimation?: boolean;
+
+  /**
    * What method to evaluate what direction to throw the card on release. 'velocity' will evaluate direction based on the direction of the swiping movement. 'position' will evaluate direction based on the position the card has on the screen like in the app tinder.
    * If set to position it is recommended to manually set swipeThreshold based on the screen size as not all devices will accommodate the default distance of 300px and the default native swipeThreshold is 1px which most likely is undesirably low.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,11 +48,11 @@ declare interface Props {
   preventSwipe?: string[]
 
   /**
-   * The card return animation is slow.
+   * The card return animation type. Valid arguments are `'standard'`, `'slow'`, `'none'`.
    *
-   * @default false
+   * @default 'standard'
    */
-  slowBackAnimation?: boolean;
+  backAnimationType?: string;
 
   /**
    * What method to evaluate what direction to throw the card on release. 'velocity' will evaluate direction based on the direction of the swiping movement. 'position' will evaluate direction based on the position the card has on the screen like in the app tinder.

--- a/index.js
+++ b/index.js
@@ -108,9 +108,9 @@ const TinderCard = React.forwardRef(
     settings.swipeThreshold = swipeThreshold
 
     const getBackAnimationType = () => {
-      if (backAnimationType == 'standard') {
+      if (backAnimationType === 'standard') {
         return physics.animateBack;
-      } else if (backAnimationType == 'slow') {
+      } else if (backAnimationType === 'slow') {
         return physics.animateSlow;
       } 
       return physics.none;

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ const physics = {
   animateBack: {
     friction: 10,
     tension: 200
+  },
+  animateBackSlow: {
+    friction: 50,
+    tension: 200
   }
 }
 
@@ -54,13 +58,6 @@ const animateOut = async (gesture, setSpringTarget, windowHeight, windowWidth) =
   )
 }
 
-const animateBack = (setSpringTarget) => {
-  // translate back to the initial position
-  return new Promise((resolve) => {
-    setSpringTarget.start({ xyrot: [0, 0, 0], config: physics.animateBack, onRest: resolve })
-  })
-}
-
 const getSwipeDirection = (property) => {
   if (Math.abs(property.x) > Math.abs(property.y)) {
     if (property.x > settings.swipeThreshold) {
@@ -83,7 +80,19 @@ const AnimatedDiv = animated.div
 
 const TinderCard = React.forwardRef(
   (
-    { flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], swipeRequirementType = 'velocity', swipeThreshold = settings.swipeThreshold, onSwipeRequirementFulfilled, onSwipeRequirementUnfulfilled },
+    {
+      flickOnSwipe = true,
+      slowBackAnimation = false,
+      children,
+      onSwipe,
+      onCardLeftScreen,
+      className,
+      preventSwipe = [],
+      swipeRequirementType = 'velocity',
+      swipeThreshold = settings.swipeThreshold,
+      onSwipeRequirementFulfilled,
+      onSwipeRequirementUnfulfilled
+    },
     ref
   ) => {
     const { width, height } = useWindowSize()
@@ -93,6 +102,19 @@ const TinderCard = React.forwardRef(
     }))
 
     settings.swipeThreshold = swipeThreshold
+
+    const animateBack = (setSpringTarget) => {
+      // translate back to the initial position
+      return new Promise((resolve) => {
+        setSpringTarget.start({
+          xyrot: [0, 0, 0],
+          config: slowBackAnimation
+            ? physics.animateBackSlow
+            : physics.animateBack,
+          onRest: resolve
+        })
+      })
+    }
 
     React.useImperativeHandle(ref, () => ({
       async swipe (dir = 'right') {

--- a/index.js
+++ b/index.js
@@ -22,9 +22,13 @@ const physics = {
     friction: 10,
     tension: 200
   },
-  animateBackSlow: {
+  animateSlow: {
     friction: 50,
     tension: 200
+  },
+  none: {
+    friction: 0,
+    tension: 0
   }
 }
 
@@ -82,7 +86,7 @@ const TinderCard = React.forwardRef(
   (
     {
       flickOnSwipe = true,
-      slowBackAnimation = false,
+      backAnimationType = 'standard',
       children,
       onSwipe,
       onCardLeftScreen,
@@ -103,14 +107,21 @@ const TinderCard = React.forwardRef(
 
     settings.swipeThreshold = swipeThreshold
 
+    const getBackAnimationType = () => {
+      if (backAnimationType == 'standard') {
+        return physics.animateBack;
+      } else if (backAnimationType == 'slow') {
+        return physics.animateSlow;
+      } 
+      return physics.none;
+    }
+
     const animateBack = (setSpringTarget) => {
       // translate back to the initial position
       return new Promise((resolve) => {
         setSpringTarget.start({
           xyrot: [0, 0, 0],
-          config: slowBackAnimation
-            ? physics.animateBackSlow
-            : physics.animateBack,
+          config: getBackAnimationType(),
           onRest: resolve
         })
       })

--- a/index.native.js
+++ b/index.native.js
@@ -23,9 +23,13 @@ const physics = {
     friction: 10,
     tension: 200
   },
-  animateBackSlow: {
+  animateSlow: {
     friction: 50,
     tension: 200
+  },
+  none: {
+    friction: 0,
+    tension: 0
   }
 }
 
@@ -85,7 +89,7 @@ const TinderCard = React.forwardRef(
   (
     {
       flickOnSwipe = true,
-      slowBackAnimation = false,
+      backAnimationType = 'standard',
       children,
       onSwipe,
       onCardLeftScreen,
@@ -106,14 +110,21 @@ const TinderCard = React.forwardRef(
     }))
     settings.swipeThreshold = swipeThreshold
 
+    const getBackAnimationType = () => {
+      if (backAnimationType == 'standard') {
+        return physics.animateBack;
+      } else if (backAnimationType == 'slow') {
+        return physics.animateSlow;
+      } 
+      return physics.none;
+    }
+
     const animateBack = (setSpringTarget) => {
       // translate back to the initial position
       return new Promise((resolve) => {
         setSpringTarget.start({
           xyrot: [0, 0, 0],
-          config: slowBackAnimation
-            ? physics.animateBackSlow
-            : physics.animateBack,
+          config: getBackAnimationType(),
           onRest: resolve
         })
       })

--- a/index.native.js
+++ b/index.native.js
@@ -111,9 +111,9 @@ const TinderCard = React.forwardRef(
     settings.swipeThreshold = swipeThreshold
 
     const getBackAnimationType = () => {
-      if (backAnimationType == 'standard') {
+      if (backAnimationType === 'standard') {
         return physics.animateBack;
-      } else if (backAnimationType == 'slow') {
+      } else if (backAnimationType === 'slow') {
         return physics.animateSlow;
       } 
       return physics.none;

--- a/index.native.js
+++ b/index.native.js
@@ -22,6 +22,10 @@ const physics = {
   animateBack: {
     friction: 10,
     tension: 200
+  },
+  animateBackSlow: {
+    friction: 50,
+    tension: 200
   }
 }
 
@@ -57,13 +61,6 @@ const animateOut = async (gesture, setSpringTarget) => {
   )
 }
 
-const animateBack = (setSpringTarget) => {
-  // translate back to the initial position
-  return new Promise((resolve) => {
-    setSpringTarget.current[0].start({ x: 0, y: 0, rot: 0, config: physics.animateBack, onRest: resolve })
-  })
-}
-
 const getSwipeDirection = (property) => {
   if (Math.abs(property.x) > Math.abs(property.y)) {
     if (property.x > settings.swipeThreshold) {
@@ -86,7 +83,19 @@ const AnimatedView = animated(View)
 
 const TinderCard = React.forwardRef(
   (
-    { flickOnSwipe = true, children, onSwipe, onCardLeftScreen, className, preventSwipe = [], swipeRequirementType = 'velocity', swipeThreshold = settings.swipeThreshold, onSwipeRequirementFulfilled, onSwipeRequirementUnfulfilled },
+    {
+      flickOnSwipe = true,
+      slowBackAnimation = false,
+      children,
+      onSwipe,
+      onCardLeftScreen,
+      className,
+      preventSwipe = [],
+      swipeRequirementType = 'velocity',
+      swipeThreshold = settings.swipeThreshold,
+      onSwipeRequirementFulfilled,
+      onSwipeRequirementUnfulfilled
+    },
     ref
   ) => {
     const [{ x, y, rot }, setSpringTarget] = useSpring(() => ({
@@ -96,6 +105,19 @@ const TinderCard = React.forwardRef(
       config: physics.touchResponsive
     }))
     settings.swipeThreshold = swipeThreshold
+
+    const animateBack = (setSpringTarget) => {
+      // translate back to the initial position
+      return new Promise((resolve) => {
+        setSpringTarget.start({
+          xyrot: [0, 0, 0],
+          config: slowBackAnimation
+            ? physics.animateBackSlow
+            : physics.animateBack,
+          onRest: resolve
+        })
+      })
+    }
 
     React.useImperativeHandle(ref, () => ({
       async swipe (dir = 'right') {

--- a/readme.md
+++ b/readme.md
@@ -104,13 +104,13 @@ Callback that will be executed when a `TinderCard` has left the screen. It will 
 
 An array of directions for which to prevent swiping out of screen. Valid arguments are `'left'`, `'right'`, `'up'` and `'down'`.
 
-### `slowBackAnimation`
+### `backAnimationType`
 
 - optional
-- type: `boolean`
-- default: `false`
+- type: `string`
+- default: `standard`
 
-The card return animation is slow.
+The card return animation type. Valid arguments are `'standard'`, `'slow'`, `'none'`.
 
 ### `swipeRequirementType`
 

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,14 @@ Callback that will be executed when a `TinderCard` has left the screen. It will 
 
 An array of directions for which to prevent swiping out of screen. Valid arguments are `'left'`, `'right'`, `'up'` and `'down'`.
 
+### `slowBackAnimation`
+
+- optional
+- type: `boolean`
+- default: `false`
+
+The card return animation is slow.
+
 ### `swipeRequirementType`
 
 - optional


### PR DESCRIPTION
The animation of the card's return (`animateBack`) is very fast and makes a very "aggressive" movement of passing to the other side. 

In order to make it possible to use a slower or even remove it altogether, I propose to introduce `backAnimationType` props that defaults to `standard` and keeps the existing operation. 

On the other hand, it will be possible to use this function and: 
- set the props to `slow`, which will delay the `animateBack` effect. 
- set the props to `none`, which will completely remove the effect of the return animation. 